### PR TITLE
handle name for decorators

### DIFF
--- a/nbdoc/showdoc.py
+++ b/nbdoc/showdoc.py
@@ -166,8 +166,6 @@ class ShowDoc:
         self.typ = get_type(self.obj) if not objtype else objtype
         if not self.typ: raise ValueError(f'Can only parse a class or a function, but got a {type(self.obj)}')
         self.npdocs = np2jsx(self.obj)
-        if name and decorator:
-            if not name.startswith('@'): name = '@' + name
 
         default_nm = self.obj.__qualname__ if self.typ == 'method' else self.obj.__name__
         self.objnm = default_nm if not name else name
@@ -186,7 +184,9 @@ class ShowDoc:
     @property
     def nbhtml(self):
         "HTML to be shown in the notebook"
-        hd_prefix = f'<h{self.hd_lvl}> <code>{self.typ}</code> <span style="color:Brown">{self.objnm}</span> <em>{self._html_signature}</em>'
+        name=self.objnm
+        if self.decorator and not name.startswith('@'):name = '@' + name
+        hd_prefix = f'<h{self.hd_lvl}> <code>{self.typ}</code> <span style="color:Brown">{name}</span> <em>{self._html_signature}</em>'
         if self.src_link: hd_prefix += f'<a href="{self.src_link}" style="float:right">[source]</a>'
         hd_prefix += f'</h{self.hd_lvl}>'
         hd_prefix += f'<strong>{self.modnm}</strong>'

--- a/nbs/showdoc.ipynb
+++ b/nbs/showdoc.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "id": "aee35186-0164-420e-bcee-fab4a5b1c96d",
    "metadata": {},
    "outputs": [],
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "id": "6f8c7592-7628-4832-bc74-cd50cd307308",
    "metadata": {},
    "outputs": [],
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "a6c28828-9b3c-4440-afa2-90381fe94450",
    "metadata": {},
    "outputs": [],
@@ -51,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "c315c54e-859c-44c5-9c4d-2499692dfbcb",
    "metadata": {},
    "outputs": [],
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "af14fe3d-bbb2-4a54-a0b7-c1fa2c9efba0",
    "metadata": {},
    "outputs": [],
@@ -89,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "fe702ea7-7325-4b5d-a8ea-bbb2557547d6",
    "metadata": {},
    "outputs": [],
@@ -108,7 +108,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "f819c03e-3d42-4672-b9e9-594ed877b901",
    "metadata": {},
    "outputs": [
@@ -131,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "2c9604d3-0de1-4a39-b19b-30d4df5ce6d1",
    "metadata": {},
    "outputs": [],
@@ -153,7 +153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "a9e05b10-6f86-4867-9437-898f619d1540",
    "metadata": {},
    "outputs": [],
@@ -167,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "ec56b89e-21c7-4d1d-8be6-1a325e4da25a",
    "metadata": {},
    "outputs": [],
@@ -207,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "735bfce7-8bfc-4217-869e-1703aec0768b",
    "metadata": {},
    "outputs": [
@@ -240,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "ecb171fd-c03e-4e3d-8016-faa316b590ee",
    "metadata": {},
    "outputs": [
@@ -274,7 +274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "999c8471-d4a1-41cd-979e-7c108aed70a8",
    "metadata": {},
    "outputs": [
@@ -309,7 +309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "id": "0325da66-1b0f-4e2c-b5e9-cdf770ab8ae4",
    "metadata": {},
    "outputs": [
@@ -338,7 +338,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "id": "3f591de4-7f00-45d1-8159-aff4204adb02",
    "metadata": {},
    "outputs": [],
@@ -367,7 +367,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "id": "0adfc434-f9ed-49a3-8061-e651e93c1669",
    "metadata": {},
    "outputs": [
@@ -377,7 +377,7 @@
        "<Signature (a: int, b: str = 'foo', c: float = 0.1, *args, **tags)>"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -397,7 +397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "id": "bbbe4731-bf49-451c-8015-cc8e1535990a",
    "metadata": {},
    "outputs": [],
@@ -412,7 +412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "id": "5c5ae88d-958a-4b59-a56e-4384ccf6b91d",
    "metadata": {},
    "outputs": [],
@@ -444,7 +444,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 21,
    "id": "31be4c90-1b8b-4943-a928-a7c2842ceaae",
    "metadata": {},
    "outputs": [
@@ -454,7 +454,7 @@
        "<Signature (a: int, b: str = 'foo', c: float = 0.1, *args, **tags)>"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -473,7 +473,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 22,
    "id": "c34a9a55-7e72-487b-926d-f1c5fdd1d729",
    "metadata": {},
    "outputs": [
@@ -501,7 +501,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 23,
    "id": "a74619c1-b53f-43db-8ba1-5b6ce43033fc",
    "metadata": {},
    "outputs": [],
@@ -512,7 +512,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 24,
    "id": "bbeb19c0-6c5d-4bac-8838-7100fcdb0a2c",
    "metadata": {},
    "outputs": [],
@@ -524,7 +524,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 25,
    "id": "355773d2-848b-4d07-aa7e-e8f63e22e9ca",
    "metadata": {},
    "outputs": [],
@@ -547,7 +547,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 26,
    "id": "1d983b4a-11cd-4c90-af89-6862321a7f86",
    "metadata": {},
    "outputs": [],
@@ -559,7 +559,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 27,
    "id": "43c2f46c-416e-4934-aafd-086db038cd30",
    "metadata": {},
    "outputs": [],
@@ -571,7 +571,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 28,
    "id": "03413772-69d6-4757-9ce0-511c2094a9b0",
    "metadata": {},
    "outputs": [],
@@ -605,7 +605,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 29,
    "id": "e3aa1d9f-7b54-4532-89cd-34eada82e483",
    "metadata": {},
    "outputs": [
@@ -617,7 +617,7 @@
        " 'fastcore': 'https://github.com/fastcore/tree/master'}"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -630,7 +630,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 30,
    "id": "47fe604c-dcda-4341-bca1-f55842eccdc1",
    "metadata": {},
    "outputs": [],
@@ -647,7 +647,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 31,
    "id": "7a0fa9ca-4ac5-4eab-8283-5c542a466b46",
    "metadata": {},
    "outputs": [],
@@ -675,7 +675,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 32,
    "id": "10e96770-4153-4507-a8d1-7d7ca1866ef8",
    "metadata": {},
    "outputs": [],
@@ -689,7 +689,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 33,
    "id": "8838f5ee-c4e4-4719-8ba2-459d0ea23993",
    "metadata": {},
    "outputs": [],
@@ -703,7 +703,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 34,
    "id": "aba26c5a-10dc-4b97-9382-3f90252b81c4",
    "metadata": {},
    "outputs": [],
@@ -729,8 +729,6 @@
     "        self.typ = get_type(self.obj) if not objtype else objtype\n",
     "        if not self.typ: raise ValueError(f'Can only parse a class or a function, but got a {type(self.obj)}')\n",
     "        self.npdocs = np2jsx(self.obj)\n",
-    "        if name and decorator:\n",
-    "            if not name.startswith('@'): name = '@' + name\n",
     "            \n",
     "        default_nm = self.obj.__qualname__ if self.typ == 'method' else self.obj.__name__\n",
     "        self.objnm = default_nm if not name else name\n",
@@ -749,7 +747,9 @@
     "    @property\n",
     "    def nbhtml(self): \n",
     "        \"HTML to be shown in the notebook\"\n",
-    "        hd_prefix = f'<h{self.hd_lvl}> <code>{self.typ}</code> <span style=\"color:Brown\">{self.objnm}</span> <em>{self._html_signature}</em>'\n",
+    "        name=self.objnm\n",
+    "        if self.decorator and not name.startswith('@'):name = '@' + name\n",
+    "        hd_prefix = f'<h{self.hd_lvl}> <code>{self.typ}</code> <span style=\"color:Brown\">{name}</span> <em>{self._html_signature}</em>'\n",
     "        if self.src_link: hd_prefix += f'<a href=\"{self.src_link}\" style=\"float:right\">[source]</a>'\n",
     "        hd_prefix += f'</h{self.hd_lvl}>'\n",
     "        hd_prefix += f'<strong>{self.modnm}</strong>'\n",
@@ -805,7 +805,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 35,
    "id": "b3b151d4-e6b8-4eef-b6a9-97f8213bb04f",
    "metadata": {},
    "outputs": [
@@ -827,10 +827,10 @@
        "</DocSection>"
       ],
       "text/plain": [
-       "<__main__.ShowDoc at 0x7fed3abf4340>"
+       "<__main__.ShowDoc at 0x7fbf70074940>"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -849,7 +849,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 36,
    "id": "647d4e79-a8db-4cc5-af22-6f2f54bbea89",
    "metadata": {},
    "outputs": [
@@ -859,7 +859,7 @@
        "<HTMLRemove>\n",
        "<h3> <code>decorator</code> <span style=\"color:Brown\">@example</span> <em>(...)</em></h3><strong>test_lib.example</strong><p><blockquote>The&nbsp;summary&nbsp;line&nbsp;for&nbsp;a&nbsp;class&nbsp;docstring&nbsp;should&nbsp;fit&nbsp;on&nbsp;one&nbsp;line.<br><br>If&nbsp;the&nbsp;class&nbsp;has&nbsp;public&nbsp;attributes,&nbsp;they&nbsp;may&nbsp;be&nbsp;documented&nbsp;here<br>in&nbsp;an&nbsp;``Attributes``&nbsp;section&nbsp;and&nbsp;follow&nbsp;the&nbsp;same&nbsp;formatting&nbsp;as&nbsp;a<br>function's&nbsp;``Args``&nbsp;section.&nbsp;Alternatively,&nbsp;attributes&nbsp;may&nbsp;be&nbsp;documented<br>inline&nbsp;with&nbsp;the&nbsp;attribute's&nbsp;declaration&nbsp;(see&nbsp;__init__&nbsp;method&nbsp;below).<br><br>Properties&nbsp;created&nbsp;with&nbsp;the&nbsp;``@property``&nbsp;decorator&nbsp;should&nbsp;be&nbsp;documented<br>in&nbsp;the&nbsp;property's&nbsp;getter&nbsp;method.<br><br>Attributes<br>----------<br>attr1&nbsp;:&nbsp;str<br>&nbsp;&nbsp;&nbsp;&nbsp;Description&nbsp;of&nbsp;`attr1`.<br>attr2&nbsp;:&nbsp;:obj:`int`,&nbsp;optional<br>&nbsp;&nbsp;&nbsp;&nbsp;Description&nbsp;of&nbsp;`attr2`.</blockquote></p>\n",
        "</HTMLRemove>\n",
-       "<DocSection type=\"decorator\" name=\"@example\" module=\"test_lib.example\" heading_level=\"3\">\n",
+       "<DocSection type=\"decorator\" name=\"example\" module=\"test_lib.example\" heading_level=\"3\">\n",
        "<SigArgSection>\n",
        "<SigArg name=\"...\" />\n",
        "</SigArgSection>\n",
@@ -871,10 +871,10 @@
        "</DocSection>"
       ],
       "text/plain": [
-       "<__main__.ShowDoc at 0x7fed3abe27c0>"
+       "<__main__.ShowDoc at 0x7fbf70061160>"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -893,7 +893,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 37,
    "id": "8fd5dabb-1e51-480e-88a9-a3c8e6c29eb4",
    "metadata": {},
    "outputs": [
@@ -903,7 +903,7 @@
        "<HTMLRemove>\n",
        "<h3> <code>decorator</code> <span style=\"color:Brown\">@example</span> <em>(...)</em></h3><strong>mymodule.foo</strong><p><blockquote>The&nbsp;summary&nbsp;line&nbsp;for&nbsp;a&nbsp;class&nbsp;docstring&nbsp;should&nbsp;fit&nbsp;on&nbsp;one&nbsp;line.<br><br>If&nbsp;the&nbsp;class&nbsp;has&nbsp;public&nbsp;attributes,&nbsp;they&nbsp;may&nbsp;be&nbsp;documented&nbsp;here<br>in&nbsp;an&nbsp;``Attributes``&nbsp;section&nbsp;and&nbsp;follow&nbsp;the&nbsp;same&nbsp;formatting&nbsp;as&nbsp;a<br>function's&nbsp;``Args``&nbsp;section.&nbsp;Alternatively,&nbsp;attributes&nbsp;may&nbsp;be&nbsp;documented<br>inline&nbsp;with&nbsp;the&nbsp;attribute's&nbsp;declaration&nbsp;(see&nbsp;__init__&nbsp;method&nbsp;below).<br><br>Properties&nbsp;created&nbsp;with&nbsp;the&nbsp;``@property``&nbsp;decorator&nbsp;should&nbsp;be&nbsp;documented<br>in&nbsp;the&nbsp;property's&nbsp;getter&nbsp;method.<br><br>Attributes<br>----------<br>attr1&nbsp;:&nbsp;str<br>&nbsp;&nbsp;&nbsp;&nbsp;Description&nbsp;of&nbsp;`attr1`.<br>attr2&nbsp;:&nbsp;:obj:`int`,&nbsp;optional<br>&nbsp;&nbsp;&nbsp;&nbsp;Description&nbsp;of&nbsp;`attr2`.</blockquote></p>\n",
        "</HTMLRemove>\n",
-       "<DocSection type=\"decorator\" name=\"@example\" module=\"mymodule.foo\" heading_level=\"3\">\n",
+       "<DocSection type=\"decorator\" name=\"example\" module=\"mymodule.foo\" heading_level=\"3\">\n",
        "<SigArgSection>\n",
        "<SigArg name=\"...\" />\n",
        "</SigArgSection>\n",
@@ -915,10 +915,10 @@
        "</DocSection>"
       ],
       "text/plain": [
-       "<__main__.ShowDoc at 0x7fed3abf44c0>"
+       "<__main__.ShowDoc at 0x7fbfc052ef10>"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -929,7 +929,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 39,
    "id": "479dae23-5809-4ed0-b2f7-2e9052c24cab",
    "metadata": {},
    "outputs": [],
@@ -937,7 +937,7 @@
     "#hide\n",
     "_res = ShowDoc(ex.ExampleClass, decorator=True, name='example').jsx\n",
     "_res\n",
-    "assert 'type=\"decorator\" name=\"@example\"' in  _res\n",
+    "assert 'type=\"decorator\" name=\"example\"' in  _res\n",
     "assert '<SigArg name=\"...\" />' in _res\n",
     "\n",
     "_res = ShowDoc(ex.ExampleClass, decorator=True, name='example', module_nm='mymod.foo').jsx\n",
@@ -954,7 +954,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 40,
    "id": "1fa340c4-e25f-4c9f-9824-5bc91d2f4685",
    "metadata": {},
    "outputs": [
@@ -987,10 +987,10 @@
        "</DocSection>"
       ],
       "text/plain": [
-       "<__main__.ShowDoc at 0x7fed3abf42b0>"
+       "<__main__.ShowDoc at 0x7fbfc052ec40>"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1001,7 +1001,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 41,
    "id": "58d33dc3-6063-4cc1-b887-df981372bde2",
    "metadata": {},
    "outputs": [],
@@ -1013,7 +1013,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 42,
    "id": "30c099e8-4bbd-4d95-8559-437edf201bad",
    "metadata": {},
    "outputs": [],
@@ -1033,7 +1033,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 43,
    "id": "076e2880-b859-4e60-b3a7-a53643b4d382",
    "metadata": {},
    "outputs": [
@@ -1052,10 +1052,10 @@
        "</DocSection>"
       ],
       "text/plain": [
-       "<__main__.ShowDoc at 0x7fed489acf10>"
+       "<__main__.ShowDoc at 0x7fbfc052ebb0>"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1074,7 +1074,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 44,
    "id": "eb890428-874c-4566-934f-60094c456827",
    "metadata": {},
    "outputs": [],
@@ -1087,7 +1087,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 45,
    "id": "8cda5649-605f-4f67-98ab-52476fe88113",
    "metadata": {},
    "outputs": [
@@ -1116,7 +1116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 46,
    "id": "4b3acc2c-d7a5-4908-a9cb-0b796ec91206",
    "metadata": {},
    "outputs": [


### PR DESCRIPTION
Taking the `@` out that is automatically injected for decorators so @obgibson can render it appropriately per this conversation: https://outerboundsco.slack.com/archives/C031ZJA4ZBR/p1649090030576589